### PR TITLE
Fix typo for 'including'

### DIFF
--- a/lang/en/simplelesson.php
+++ b/lang/en/simplelesson.php
@@ -241,7 +241,7 @@ $string['privacy:metadata:simplelesson_attempts'] = 'Information about users sim
 $string['privacy:metadata:simplelesson_attempts:userid'] = 'The id of the user taking the attempt.';
 $string['privacy:metadata:simplelesson_attempts:status'] = 'The completion status of the attempt.';
 $string['privacy:metadata:simplelesson_attempts:sessionscore'] = 'The score achieved on the attempt.';
-$string['privacy:metadata:simplelesson_attempts:timetaken'] = 'The timetaken to complete the attempt (seconds).';
+$string['privacy:metadata:simplelesson_attempts:timetaken'] = 'The time taken to complete the attempt (seconds).';
 
 $string['privacy:metadata:simplelesson_answers'] = 'Information about users simplelesson attempts at individual questions including their response and a score.';
 $string['privacy:metadata:simplelesson_answers:mark'] = 'The score of the user answering the question.';

--- a/lang/en/simplelesson.php
+++ b/lang/en/simplelesson.php
@@ -33,7 +33,7 @@ $string['modulename_help'] = 'Use the Simple lesson module for a simple sequenti
 
 It allows the use of questions from a selected question bank. Valid question types that have been tested are true/false, multiple choice (one answer), match, gapselect and short answer.  Essay questions are allowed and need to be manually marked.  Question behaviours implemented are adaptive, immediate and deferred feedback (without CBM).
 
-User attempt data, includind detailed question responses are recorded and marked.  Grading strategies used for multiple attempts are Highest, Average and Last attempt(s).
+User attempt data, including detailed question responses are recorded and marked.  Grading strategies used for multiple attempts are Highest, Average and Last attempt(s).
 
 Simplelessons and their content pages are backed up but questions are not.';
 $string['simplelessonfieldset'] = 'Custom example fieldset';


### PR DESCRIPTION
Hi,
When I was trying your plugin, I came across this tiny typo in one English language string.